### PR TITLE
ERNEST-1917: Check if name arg is received and build the query

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -61,6 +61,10 @@ func getParamFilter(c echo.Context) map[string]interface{} {
 		}
 	}
 
+	if c.Param("name") != "" {
+		query["name"] = c.Param("name")
+	}
+
 	if c.Param("service") != "" {
 		query["name"] = c.Param("service")
 	}

--- a/helpers.go
+++ b/helpers.go
@@ -49,7 +49,7 @@ func authenticatedUser(c echo.Context) User {
 func getParamFilter(c echo.Context) map[string]interface{} {
 	query := make(map[string]interface{})
 
-	fields := []string{"group", "user", "group", "datacenter"}
+	fields := []string{"group", "user", "datacenter"}
 
 	// Process ID's as int's
 	for _, field := range fields {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package main
+
+import (
+	"testing"
+
+	"github.com/labstack/echo"
+	"github.com/labstack/echo/test"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestGetParamFilter(t *testing.T) {
+	e := echo.New()
+	req := test.NewRequest(echo.GET, "/", nil)
+	rec := test.NewResponseRecorder()
+	Convey("Scenario: getting an empty http context", t, func() {
+		c := e.NewContext(req, rec)
+		Convey("when it is converted to a query", func() {
+			query := getParamFilter(c)
+			Convey("the query is also empty", func() {
+				So(query, ShouldNotBeNil)
+				So(len(query), ShouldEqual, 0)
+			})
+		})
+	})
+}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -43,4 +43,20 @@ func TestGetParamFilter(t *testing.T) {
 		})
 	})
 
+	Convey("Scenario: getting an http context", t, func() {
+		c := e.NewContext(req, rec)
+		Convey("when it has a service paramater", func() {
+			c.SetParamNames("service")
+			c.SetParamValues("somename")
+			Convey("and it is converted to a query", func() {
+				query := getParamFilter(c)
+				Convey("the query has the name and its value", func() {
+					So(query, ShouldNotBeNil)
+					So(len(query), ShouldEqual, 1)
+					So(query["name"], ShouldEqual, "somename")
+				})
+			})
+		})
+	})
+
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -59,4 +59,20 @@ func TestGetParamFilter(t *testing.T) {
 		})
 	})
 
+	Convey("Scenario: getting an http context", t, func() {
+		c := e.NewContext(req, rec)
+		Convey("when it has a build paramater", func() {
+			c.SetParamNames("build")
+			c.SetParamValues("someid")
+			Convey("and it is converted to a query", func() {
+				query := getParamFilter(c)
+				Convey("the query has the id and its value", func() {
+					So(query, ShouldNotBeNil)
+					So(len(query), ShouldEqual, 1)
+					So(query["id"], ShouldEqual, "someid")
+				})
+			})
+		})
+	})
+
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -26,4 +26,21 @@ func TestGetParamFilter(t *testing.T) {
 			})
 		})
 	})
+
+	Convey("Scenario: getting an http context", t, func() {
+		c := e.NewContext(req, rec)
+		Convey("when it has a name paramater", func() {
+			c.SetParamNames("name")
+			c.SetParamValues("somename")
+			Convey("and it is converted to a query", func() {
+				query := getParamFilter(c)
+				Convey("the query has the name and its value", func() {
+					So(query, ShouldNotBeNil)
+					So(len(query), ShouldEqual, 1)
+					So(query["name"], ShouldEqual, "somename")
+				})
+			})
+		})
+	})
+
 }


### PR DESCRIPTION
Fixes the problem of getting the definition for a service and its name but not using the build id.