### PR TITLE
Add a delay between service.save and service.create

### DIFF
--- a/services.go
+++ b/services.go
@@ -248,6 +248,7 @@ func createServiceHandler(c echo.Context) error {
 	options := "{}"
 	mapping := string(service)
 	saveService(payload.ID, s.Name, datacenterStruct.Type, version, status, options, string(definition), mapping, uint(au.GroupID), datacenterStruct.ID)
+	time.Sleep(1 * time.Second)
 
 	// Apply changes
 	n.Publish("service.create", service)
@@ -281,6 +282,7 @@ func deleteServiceHandler(c echo.Context) error {
 	if msg, err := n.Request("definition.map.deletion", query, 1*time.Second); err != nil {
 		return c.JSONBlob(500, []byte(`"Couldn't map the service"`))
 	} else {
+		time.Sleep(1 * time.Second)
 		n.Publish("service.delete", msg.Data)
 	}
 

--- a/services_helpers.go
+++ b/services_helpers.go
@@ -331,6 +331,5 @@ func saveService(id string, name string, t string, v time.Time, s string, o stri
 
 	body, _ := json.Marshal(payload)
 
-	println(string(body))
 	n.Publish("service.set", body)
 }


### PR DESCRIPTION
This is a quick fix, and may be followed by an r&d task in order to see if is possible to consume queued messages on a fifo queue through nats. Otherwise we will need to rethink how stores processes the messages.