### PR TITLE
[#ERNEST-130] : New GET /status endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ func main() {
 	e.Use(middleware.Logger())
 	e.Use(middleware.Recover())
 	e.POST("/auth", authenticate)
+	e.GET("/status", getStatusHandler)
 
 	// Setup JWT auth & protected routes
 	api := e.Group("/api")

--- a/status.go
+++ b/status.go
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package main
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo"
+)
+
+// getStatusHandler : responds to GET /status/
+func getStatusHandler(c echo.Context) (err error) {
+	return c.JSONBlob(http.StatusOK, []byte(`"success"`))
+}


### PR DESCRIPTION
Setup a status checker on GET `http://ernest.api/status`
```
$ curl -i --insecure http://ernest.local:8080/status
HTTP/1.1 200 OK
Content-Type: application/json; charset=utf-8
Date: Wed, 16 Nov 2016 11:39:02 GMT
Content-Length: 9

"success"
```

Fixes https://github.com/ernestio/ernest/issues/130